### PR TITLE
Bring over from purescript-markdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/.*
+!/.gitignore
+!/.travis.yml
+/output/
+/node_modules/
+/bower_components/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+sudo: false
+node_js:
+  - 0.10
+install:
+  - npm install gulp bower -g
+  - npm install
+  - bower update
+script:
+  - gulp

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,19 @@
+{
+  "name": "purescript-markdown-halogen",
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "bower_components",
+    "node_modules",
+    "output",
+    "example",
+    "test",
+    "bower.json",
+    "gulpfile.js",
+    "package.json"
+  ],
+  "dependencies": {
+    "purescript-markdown": "~1.5.0",
+    "purescript-halogen": "b1636e2537526963f89134c7b4fd8005c1b62e37"
+  }
+}

--- a/docs/Text.Markdown.SlamDown.Html.md
+++ b/docs/Text.Markdown.SlamDown.Html.md
@@ -1,0 +1,73 @@
+# Module Documentation
+
+## Module Text.Markdown.SlamDown.Html
+
+
+This module defines functions for rendering Markdown to HTML.
+
+#### `FormFieldValue`
+
+``` purescript
+data FormFieldValue
+  = SingleValue TextBoxType String
+  | MultipleValues (S.Set String)
+```
+
+
+#### `showFormFieldValue`
+
+``` purescript
+instance showFormFieldValue :: Show FormFieldValue
+```
+
+
+#### `SlamDownState`
+
+``` purescript
+newtype SlamDownState
+  = SlamDownState (M.StrMap FormFieldValue)
+```
+
+The state of a SlamDown form - a mapping from input keys to values
+
+#### `showSlamDownState`
+
+``` purescript
+instance showSlamDownState :: Show SlamDownState
+```
+
+
+#### `emptySlamDownState`
+
+``` purescript
+emptySlamDownState :: SlamDownState
+```
+
+The state of an empty form, in which all fields use their default values
+
+#### `SlamDownEvent`
+
+``` purescript
+data SlamDownEvent
+```
+
+The type of events which can be raised by SlamDown forms
+
+#### `applySlamDownEvent`
+
+``` purescript
+applySlamDownEvent :: SlamDownState -> SlamDownEvent -> SlamDownState
+```
+
+Apply a `SlamDownEvent` to a `SlamDownState`.
+
+#### `renderHalogen`
+
+``` purescript
+renderHalogen :: forall f. (Alternative f) => String -> SlamDownState -> SlamDown -> [H.HTML (f SlamDownEvent)]
+```
+
+Render the SlamDown AST to an arbitrary Halogen HTML representation
+
+
+

--- a/example/output/.gitignore
+++ b/example/output/.gitignore
@@ -1,0 +1,1 @@
+example.js

--- a/example/output/index.html
+++ b/example/output/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+<head>
+    <title>purescript-markdown example</title>
+    <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+    <script src="example.js"></script>
+</body>
+</html>

--- a/example/src/Main.purs
+++ b/example/src/Main.purs
@@ -1,0 +1,69 @@
+module Main where
+
+import Data.Void
+import Data.Tuple
+import Data.Either
+
+import DOM
+
+import Data.DOM.Simple.Document
+import Data.DOM.Simple.Element
+import Data.DOM.Simple.Types
+import Data.DOM.Simple.Window
+
+import Control.Monad.Eff
+import Control.Alternative
+
+import Halogen
+import Halogen.Signal
+import Halogen.Component
+
+import qualified Halogen.HTML as H
+import qualified Halogen.HTML.Attributes as A
+import qualified Halogen.HTML.Events as A
+import qualified Halogen.HTML.Events.Forms as A
+
+import Text.Markdown.SlamDown
+import Text.Markdown.SlamDown.Html
+import Text.Markdown.SlamDown.Parser
+
+appendToBody :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Unit
+appendToBody e = do
+  w <- document globalWindow
+  b <- body w
+  appendChild b e
+
+data State = State String SlamDownState
+
+data Input
+  = DocumentChanged String
+  | FormFieldChanged SlamDownEvent
+
+ui :: forall f eff. (Alternative f) => Component f Input Input
+ui = render <$> stateful (State "" emptySlamDownState) update
+  where
+  render :: State -> H.HTML (f Input)
+  render (State md form) =
+    H.div [ A.class_ (A.className "container") ]
+          [ H.h2_ [ H.text "Markdown" ]
+          , H.div_ [ H.textarea [ A.class_ (A.className "form-control")
+                                , A.value md
+                                , A.onInput (A.input DocumentChanged)
+                                ] [] ]
+          , H.h2_ [ H.text "HTML Output" ]
+          , H.div [ A.class_ (A.className "well") ] (output md form)
+          , H.h2_ [ H.text "Form State" ]
+          , H.pre_ [ H.code_ [ H.text (show form) ] ]
+          ]
+
+  output :: String -> SlamDownState -> [H.HTML (f Input)]
+  output md form = ((FormFieldChanged <$>) <$>) <$> renderHalogen "slamdown-example" form (parseMd md)
+
+  update :: State -> Input -> State
+  update (State _ form) (DocumentChanged md) = State md form
+  update (State s form) (FormFieldChanged e) = State s (applySlamDownEvent form e)
+
+main = do
+  Tuple node driver <- runUI ui
+  appendToBody node
+

--- a/example/src/entry.js
+++ b/example/src/entry.js
@@ -1,0 +1,1 @@
+require("Main").main();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,54 @@
+"use strict";
+
+var gulp = require("gulp");
+var purescript = require("gulp-purescript");
+var jsvalidate = require("gulp-jsvalidate");
+var rimraf = require("rimraf");
+var webpack = require("webpack-stream");
+
+gulp.task("clean-docs", function (cb) {
+  rimraf("docs", cb);
+});
+
+gulp.task("clean-output", function (cb) {
+  rimraf("output", cb);
+});
+
+gulp.task("clean", ["clean-docs", "clean-output"]);
+
+gulp.task("make", function() {
+  return gulp.src(["src/**/*.purs", "example/**/*.purs", "bower_components/purescript-*/src/**/*.purs"])
+    .pipe(purescript.pscMake());
+});
+
+gulp.task("example", ["make"], function() {
+  return gulp.src("example/src/entry.js")
+    .pipe(webpack({
+      resolve: { modulesDirectories: [ "node_modules", "output" ] },
+      output: { filename: "example.js" }
+    }))
+    .pipe(gulp.dest("example/output"));
+});
+
+gulp.task("jsvalidate", ["make"], function () {
+  return gulp.src("output/**/*.js")
+    .pipe(jsvalidate());
+});
+
+var docTasks = [];
+
+var docTask = function(name) {
+  var taskName = "docs-" + name.toLowerCase();
+  gulp.task(taskName, ["clean-docs"], function () {
+    return gulp.src("src/" + name.replace(/\./g, "/") + ".purs")
+      .pipe(purescript.pscDocs())
+      .pipe(gulp.dest("docs/" + name + ".md"));
+  });
+  docTasks.push(taskName);
+};
+
+["Text.Markdown.SlamDown.Html"].forEach(docTask);
+
+gulp.task("docs", docTasks);
+
+gulp.task("default", ["jsvalidate", "docs", "make", "example"]);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "purescript-markdown-halogen",
+  "private": true,
+  "devDependencies": {
+    "gulp": "^3.8.11",
+    "gulp-jsvalidate": "^1.0.1",
+    "gulp-purescript": "^0.4.0",
+    "purescript": "^0.6.10",
+    "rimraf": "^2.3.3",
+    "virtual-dom": "^2.0.1",
+    "webpack-stream": "^2.0.0"
+  }
+}

--- a/src/Text/Markdown/SlamDown/Html.purs
+++ b/src/Text/Markdown/SlamDown/Html.purs
@@ -1,0 +1,208 @@
+-- | This module defines functions for rendering Markdown to HTML.
+
+module Text.Markdown.SlamDown.Html
+  ( SlamDownEvent()
+  , SlamDownState(..)
+  , FormFieldValue(..)
+  , emptySlamDownState
+  , applySlamDownEvent
+  , renderHalogen
+  )
+  where
+
+import Data.Maybe
+import Data.Array (concat, map, concatMap, zipWith)
+import Data.String (joinWith)
+import Data.Foldable (foldMap)
+import Data.Traversable (traverse, zipWithA)
+import Data.Identity
+
+import qualified Data.StrMap as M
+import qualified Data.Set as S
+
+import Control.Alternative
+import Control.Monad.State (State(), evalState)
+import Control.Monad.State.Class (get, modify)
+
+import Text.Markdown.SlamDown
+import Text.Markdown.SlamDown.Parser
+
+import Halogen
+import Halogen.HTML.Renderer.String (renderHTMLToString)
+
+import qualified Halogen.HTML as H
+import qualified Halogen.HTML.Attributes as A
+import qualified Halogen.HTML.Events as E
+import qualified Halogen.HTML.Events.Forms as E
+
+data FormFieldValue
+  = SingleValue TextBoxType String
+  | MultipleValues (S.Set String)
+
+instance showFormFieldValue :: Show FormFieldValue where
+  show (SingleValue t s) = "(SingleValue " ++ show t ++ " " ++ show s ++ ")"
+  show (MultipleValues ss) = "(MultipleValues " ++ show ss ++ ")"
+
+-- | The state of a SlamDown form - a mapping from input keys to values
+newtype SlamDownState = SlamDownState (M.StrMap FormFieldValue)
+
+instance showSlamDownState :: Show SlamDownState where
+  show (SlamDownState m) = "(SlamDownState " ++ show m ++ ")"
+
+-- | The state of an empty form, in which all fields use their default values
+emptySlamDownState :: SlamDownState
+emptySlamDownState = SlamDownState M.empty
+
+-- | The type of events which can be raised by SlamDown forms
+data SlamDownEvent
+  = TextChanged TextBoxType String String
+  | CheckBoxChanged String String Boolean
+
+-- | Apply a `SlamDownEvent` to a `SlamDownState`.
+applySlamDownEvent :: SlamDownState -> SlamDownEvent -> SlamDownState
+applySlamDownEvent (SlamDownState m) (TextChanged t key val) =
+  SlamDownState (M.insert key (SingleValue t val) m)
+applySlamDownEvent (SlamDownState m) (CheckBoxChanged key val checked) =
+  SlamDownState (M.alter (Just <<< updateSet) key m)
+  where
+  updateSet :: Maybe FormFieldValue -> FormFieldValue
+  updateSet (Just (MultipleValues s))
+    | checked = MultipleValues (S.insert val s)
+    | otherwise = MultipleValues (S.delete val s)
+  updateSet _
+    | checked = MultipleValues (S.singleton val)
+    | otherwise = MultipleValues S.empty
+
+type Fresh = State Number
+
+-- | Render the SlamDown AST to an arbitrary Halogen HTML representation
+renderHalogen :: forall f. (Alternative f) => String -> SlamDownState -> SlamDown -> [H.HTML (f SlamDownEvent)]
+renderHalogen formName (SlamDownState m) (SlamDown bs) = evalState (traverse renderBlock bs) 1
+
+  where
+
+  renderBlock :: Block -> Fresh (H.HTML (f SlamDownEvent))
+  renderBlock (Paragraph is) = H.p_ <$> traverse renderInline is
+  renderBlock (Header level is) = h_ level <$> traverse renderInline is
+    where
+    h_ :: forall a. Number -> [H.HTML (f a)] -> H.HTML (f a)
+    h_ 1 = H.h1_
+    h_ 2 = H.h2_
+    h_ 3 = H.h3_
+    h_ 4 = H.h4_
+    h_ 5 = H.h5_
+    h_ 6 = H.h6_
+  renderBlock (Blockquote bs) = H.blockquote_ <$> traverse renderBlock bs
+  renderBlock (List lt bss) = el_ lt <$> traverse item bss
+    where
+    el_ :: forall a. ListType -> [H.HTML (f a)] -> H.HTML (f a)
+    el_ (Bullet _)  = H.ul_
+    el_ (Ordered _) = H.ol_
+    item :: [Block] -> Fresh (H.HTML (f SlamDownEvent))
+    item bs = H.li_ <$> traverse renderBlock bs
+  renderBlock (CodeBlock _ ss) =
+    pure $ H.pre_ [ H.code_ [ H.text (joinWith "\n" ss) ] ]
+  renderBlock (LinkReference l url) =
+    pure $ H.p_ [ H.text (l <> ": ")
+                , H.a [ A.name l, A.id_ l, A.href url ] [ H.text url ]
+                ]
+  renderBlock Rule = pure $ H.hr_ []
+
+  renderInline :: Inline -> Fresh (H.HTML (f SlamDownEvent))
+  renderInline (Str s) = pure $ H.text s
+  renderInline (Entity s) = pure $ H.text s
+  renderInline Space = pure $ H.text " "
+  renderInline SoftBreak = pure $ H.text "\n"
+  renderInline LineBreak = pure $ H.br_ []
+  renderInline (Emph is) = H.em_ <$> traverse renderInline is
+  renderInline (Strong is) = H.strong_ <$> traverse renderInline is
+  renderInline (Code _ c) = pure $ H.code_ [ H.text c ]
+  renderInline (Link body tgt) = H.a [ A.href (href tgt) ] <$> traverse renderInline body
+    where
+    href (InlineLink url) = url
+    href (ReferenceLink tgt) = maybe "" ("#" ++) tgt
+  renderInline (Image body url) = H.img [ A.src url ] <$> traverse renderInline body
+  renderInline (FormField label req el) = do
+    id <- fresh
+    el' <- renderFormElement id label el
+    pure $ H.span_ $ [ H.label (if requiresId then [ A.for id ] else [])
+                               [ H.text (label ++ requiredLabel) ]
+                     , el'
+                     ]
+    where
+    requiredLabel = if req then "*" else ""
+    requiresId = case el of
+      CheckBoxes _ _ -> false
+      RadioButtons _ _ -> false
+      _ -> true
+
+  renderFormElement :: String -> String -> FormField -> Fresh (H.HTML (f SlamDownEvent))
+  renderFormElement id label (TextBox t (Literal value)) =
+    pure $ H.input [ A.type_ type'
+                   , A.id_ id
+                   , A.name label
+                   , A.value (lookupTextValue label value)
+                   , E.onInput (E.input (TextChanged t label))
+                   ] []
+    where type' = case t of
+            PlainText -> "text"
+            Date -> "date"
+            Time -> "time"
+            DateTime -> "datetime-local"
+  renderFormElement _ label (RadioButtons (Literal def) (Literal ls)) =
+    H.ul_ <$> traverse (\val -> radio (val == sel) val) (def : ls)
+    where
+    sel = lookupTextValue label def
+    radio checked value = do
+      id <- fresh
+      pure $ H.li_ [ H.input [ A.checked checked
+                             , A.type_ "radio"
+                             , A.id_ id
+                             , A.name label
+                             , A.value value
+                             , E.onChange (E.input_ (TextChanged PlainText label value))
+                             ] []
+                   , H.label [ A.for id ] [ H.text value ]
+                   ]
+  renderFormElement _ label (CheckBoxes (Literal bs) (Literal ls)) =
+    H.ul_ <$> zipWithA checkBox (lookupMultipleValues label bs ls) ls
+    where
+    checkBox checked value = do
+      id <- fresh
+      pure $ H.li_ [ H.input [ A.checked checked
+                             , A.type_ "checkbox"
+                             , A.id_ id
+                             , A.name label
+                             , A.value value
+                             , E.onChecked (E.input (CheckBoxChanged label value))
+                             ] []
+                   , H.label [ A.for id ] [ H.text value ]
+                   ]
+  renderFormElement id label (DropDown (Literal ls) (Literal sel)) = do
+    pure $ H.select [ A.id_ id
+                    , A.name label
+                    , E.onInput (E.input (TextChanged PlainText label))
+                    ]
+                    $ map option ls
+    where
+    sel' = lookupTextValue label sel
+    option value = H.option [ A.selected (value == sel'), A.value value ] [ H.text value ]
+  renderFormElement _ _ _ = pure $ H.text "Unsupported form element"
+
+  lookupTextValue :: String -> String -> String
+  lookupTextValue key def =
+    case M.lookup key m of
+      Just (SingleValue _ val) -> val
+      _ -> def
+
+  lookupMultipleValues :: String -> [Boolean] -> [String] -> [Boolean]
+  lookupMultipleValues key def ls =
+    case M.lookup key m of
+      Just (MultipleValues val) -> (`S.member` val) <$> ls
+      _ -> def
+
+  fresh :: Fresh String
+  fresh = do
+    n <- get :: Fresh Number
+    modify (+ 1)
+    pure (formName ++ "-" ++ show n)


### PR DESCRIPTION
Also a few updates:
- form element `id`s are now generated to ensure they are unique
- `label`s now properly target checkbox and radio options
- rendered HTML has a little more structure to make styling possible (radio/checkbox options are rendered in a `ul` now, for instance)

/cc @jdegoes
