### PR TITLE
Proposed/naïve fix for #8

### DIFF
--- a/src/Text/Markdown/SlamDown/Html.purs
+++ b/src/Text/Markdown/SlamDown/Html.purs
@@ -15,7 +15,7 @@ import Control.Alternative (Alternative)
 import Control.Monad.State (State(), evalState)
 import Control.Monad.State.Class (get, modify)
 
-import Data.Maybe (Maybe(..), maybe)
+import Data.Maybe (Maybe(..), maybe, fromMaybe)
 import Data.List (List(..), mapMaybe, fromList, zipWithA, zip, singleton)
 import Data.Monoid (mempty)
 import Data.String (joinWith)
@@ -228,10 +228,11 @@ renderHalogen formName (SlamDownState m) (SlamDown bs) = evalState (traverse ren
 renderTextInput :: forall f. (Alternative f) => String -> String -> TextBoxType -> Maybe String -> H.HTML (f SlamDownEvent)
 renderTextInput id label t value =
   H.input ([ A.type_ (textBoxTypeName t)
-          , A.id_ id
-          , A.name label
-          , E.onInput (E.input (TextChanged t label))
-          ] <> maybe [] (Array.singleton <<< A.value) value) []
+           , A.id_ id
+           , A.name label
+           , E.onInput (E.input (TextChanged t label))
+           , A.value (fromMaybe "" value)
+           ]) []
 
 renderDropDown :: forall f. (Alternative f) => String -> String -> List String -> Maybe String -> H.HTML (f SlamDownEvent)
 renderDropDown id label ls sel =


### PR DESCRIPTION
[This is a request for feedback, not necessarily a pull request.]

This at least fixes the observed behavior in #8, but I am not sure if it may cause some other undesirable side effect.

I had the idea for this "fix" in the course of testing out different scenarios with the date input field. It turns out that if you edit the field (and, as usual, experience the bug), and then hit the `(x)` button to clear it, subsequent edits will not suffer from the strange behavior. So it seemed to me that the solution was to provide the date input field with an (empty) default value.

Does anyone have any insight as to whether this is an acceptable solution, or if it will cause other problems?

@garyb @jdegoes 
