### PR TITLE
Resolve #11 using purescript-browserfeatures

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,9 +13,11 @@
     "package.json"
   ],
   "dependencies": {
+    "purescript-browserfeatures": "^0.2.1",
     "purescript-halogen": "30e8b2c7174a1eeda73f67cc42c739ca24a1e218",
     "purescript-markdown": "^1.8.0",
-    "purescript-validation": "^0.2.0"
+    "purescript-validation": "^0.2.0",
+    "purescript-prelude": "^0.1.2"
   },
   "resolutions": {
     "purescript-strings": "^0.7.0"

--- a/docs/Text/Markdown/SlamDown/Html.md
+++ b/docs/Text/Markdown/SlamDown/Html.md
@@ -29,6 +29,14 @@ The state of a SlamDown form - a mapping from input keys to values
 instance showSlamDownState :: Show SlamDownState
 ```
 
+#### `defaultBrowserFeatures`
+
+``` purescript
+defaultBrowserFeatures :: BrowserFeatures
+```
+
+By default, all features are enabled.
+
 #### `initSlamDownState`
 
 ``` purescript
@@ -56,7 +64,7 @@ Apply a `SlamDownEvent` to a `SlamDownState`.
 #### `renderHalogen`
 
 ``` purescript
-renderHalogen :: forall f. (Alternative f) => String -> SlamDownState -> SlamDown -> Array (HTML (f SlamDownEvent))
+renderHalogen :: forall f. (Alternative f) => BrowserFeatures -> String -> SlamDownState -> SlamDown -> Array (HTML (f SlamDownEvent))
 ```
 
 Render the SlamDown AST to an arbitrary Halogen HTML representation


### PR DESCRIPTION
This will allow clients of this interface to selectively tune SlamDown rendering to support various browser features, gracefully falling back to sensible defaults. Currently, the only such feature that where we
have observed the need for this is in the admissible `TextBoxType` constructors, but as we discover more such cases, these may be added to `SlamDownFeatureSupport`.

Resolves #11.
