### PR TITLE
Fix the travis build

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,5 +16,8 @@
     "purescript-halogen": "30e8b2c7174a1eeda73f67cc42c739ca24a1e218",
     "purescript-markdown": "^1.8.0",
     "purescript-validation": "^0.2.0"
+  },
+  "resolutions": {
+    "purescript-strings": "^0.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "gulp": "^3.9.0",
     "gulp-jsvalidate": "^2.0.0",
     "gulp-purescript": "^0.5.0",
-    "purescript": "^0.7.1",
+    "purescript": "^0.7.1 && <= 0.7.2",
     "rimraf": "^2.4.1",
     "virtual-dom": "^2.0.1",
     "webpack-stream": "^2.0.0"


### PR DESCRIPTION
I realized that it was not #12 that was breaking the build—it was already broken on master :astonished: 
- Added a resolution to `^0.7.0` for `purescript-strings`; I would prefer not to do this, but there's a conflict somewhere in the dependency tree. I think we also have this resolution in `slamdata` though.
- This project does not build anymore with the latest PureScript compiler, since it depends on a version of `purescript-halogen` that depends on `purescript-simple-dom`, which is operating a large-scale orphanage. For this reason, I have put an upper-bound in the purescript version (0.7.2) until we are able to either fix `purescript-simple-dom` or not depend on it.

Is this an acceptable (temporary) fix, or perhaps someone may have a suggestion for improvement? @cryogenian 
