### PR TITLE
Upgrade to Halogen 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-  - 0.10
+  - 0.12.7
 install:
   - npm install gulp bower -g
   - npm install

--- a/bower.json
+++ b/bower.json
@@ -13,15 +13,12 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-browserfeatures": "^0.3.0",
-    "purescript-halogen": "30e8b2c7174a1eeda73f67cc42c739ca24a1e218",
-    "purescript-markdown": "^1.9.1",
+    "purescript-browserfeatures": "^0.4.1",
+    "purescript-halogen": "^0.5.0",
+    "purescript-markdown": "^1.10.0",
     "purescript-validation": "^0.2.0",
     "purescript-prelude": "^0.1.2",
-    "purescript-strongcheck": "^0.12.1"
-  },
-  "resolutions": {
-    "purescript-strings": "^0.7.0",
-    "purescript-enums": "^0.5.0"
+    "purescript-sets": "^0.5.0",
+    "purescript-strongcheck": "^0.13.0"
   }
 }

--- a/docs/Text/Markdown/SlamDown/Html.md
+++ b/docs/Text/Markdown/SlamDown/Html.md
@@ -1,6 +1,6 @@
 ## Module Text.Markdown.SlamDown.Html
 
-This module defines functions for rendering Markdown to HTML.
+This module defines a component for rendering SlamDown documents to HTML
 
 #### `FormFieldValue`
 
@@ -16,14 +16,26 @@ instance arbitraryFormFieldValue :: Arbitrary FormFieldValue
 instance showFormFieldValue :: Show FormFieldValue
 ```
 
+#### `SlamDownFormState`
+
+``` purescript
+type SlamDownFormState = StrMap FormFieldValue
+```
+
+#### `SlamDownStateR`
+
+``` purescript
+type SlamDownStateR = { document :: SlamDown, formState :: SlamDownFormState }
+```
+
 #### `SlamDownState`
 
 ``` purescript
 newtype SlamDownState
-  = SlamDownState (StrMap FormFieldValue)
+  = SlamDownState SlamDownStateR
 ```
 
-The state of a SlamDown form - a mapping from input keys to values
+The state of a SlamDown form
 
 ##### Instances
 ``` purescript
@@ -39,41 +51,62 @@ defaultBrowserFeatures :: BrowserFeatures
 
 By default, all features are enabled.
 
-#### `initSlamDownState`
+#### `emptySlamDownState`
 
 ``` purescript
-initSlamDownState :: SlamDown -> SlamDownState
+emptySlamDownState :: SlamDownState
+```
+
+#### `makeSlamDownState`
+
+``` purescript
+makeSlamDownState :: SlamDown -> SlamDownState
 ```
 
 The initial state of form, in which all fields use their default values
 
-#### `SlamDownEvent`
+#### `SlamDownQuery`
 
 ``` purescript
-data SlamDownEvent
+data SlamDownQuery a
+  = TextChanged TextBoxType String String a
+  | CheckBoxChanged String String Boolean a
+  | SetDocument SlamDown a
+  | GetFormState (SlamDownFormState -> a)
 ```
-
-The type of events which can be raised by SlamDown forms
 
 ##### Instances
 ``` purescript
-instance arbitrarySlamDownEvent :: Arbitrary SlamDownEvent
+instance functorSlamDownQuery :: Functor SlamDownQuery
+instance arbitrarySlamDownQuery :: (Arbitrary a) => Arbitrary (SlamDownQuery a)
 ```
 
-#### `applySlamDownEvent`
+#### `evalSlamDownQuery`
 
 ``` purescript
-applySlamDownEvent :: SlamDownState -> SlamDownEvent -> SlamDownState
+evalSlamDownQuery :: forall g. Eval SlamDownQuery SlamDownState SlamDownQuery g
 ```
 
-Apply a `SlamDownEvent` to a `SlamDownState`.
-
-#### `renderHalogen`
+#### `SlamDownConfig`
 
 ``` purescript
-renderHalogen :: forall f. (Alternative f) => BrowserFeatures -> String -> SlamDownState -> SlamDown -> Array (HTML (f SlamDownEvent))
+type SlamDownConfig = { browserFeatures :: BrowserFeatures, formName :: String }
 ```
 
-Render the SlamDown AST to an arbitrary Halogen HTML representation
+#### `renderSlamDown`
+
+``` purescript
+renderSlamDown :: SlamDownConfig -> Render SlamDownState SlamDownQuery
+```
+
+Render a `SlamDown` document into an HTML form.
+
+#### `slamDownComponent`
+
+``` purescript
+slamDownComponent :: forall g. SlamDownConfig -> Component SlamDownState SlamDownQuery g
+```
+
+Bundles up the SlamDown renderer and state machine into a Halogen component.
 
 

--- a/example/src/Main.purs
+++ b/example/src/Main.purs
@@ -1,92 +1,108 @@
 module Main where
 
 import Prelude
-import Data.Array ((\\))
-import Data.Monoid
-import Data.Void
-import Data.Tuple
-import Data.Either
-import Data.Foldable
+import Data.Maybe (maybe)
 import qualified Data.StrMap as SM
 
 import DOM
 import DOM.BrowserFeatures.Detectors
 
 import Data.BrowserFeatures
+import Data.Functor.Coproduct
+import Data.NaturalTransformation (Natural())
 
-import Data.DOM.Simple.Document
-import Data.DOM.Simple.Element
-import Data.DOM.Simple.Types
-import Data.DOM.Simple.Window
-import Data.DOM.Simple.Events
-
+import Control.Monad.Aff (runAff)
+import Control.Monad.Aff.AVar (AVAR())
 import Control.Monad.Eff
-import Control.Alternative
+import Control.Monad.Eff.Exception (EXCEPTION(), throwException)
+import Control.Monad.Free (Free())
+import Control.Plus
 
-import Halogen
-import Halogen.Signal
-import Halogen.Component
+import qualified Halogen (modify, get, request, action, runUI, ChildF(..), HalogenF(), QueryF()) as H
+import qualified Halogen.Util (appendToBody) as H
+import qualified Halogen.Component as H
 
-import qualified Halogen.HTML as H
-import qualified Halogen.HTML.Attributes as A
-import qualified Halogen.HTML.Events as A
-import qualified Halogen.HTML.Events.Forms as A
+import qualified Halogen.HTML.Indexed as H
+import qualified Halogen.HTML.Properties.Indexed as P
+import qualified Halogen.HTML.Events.Indexed as E
 
 import Text.Markdown.SlamDown
 import Text.Markdown.SlamDown.Html
 import Text.Markdown.SlamDown.Parser
 
-onLoad :: forall e. Eff (dom :: DOM | e) Unit -> Eff (dom :: DOM | e) Unit
-onLoad action = do
-  let handler :: DOMEvent -> _
-      handler _ = action
-  addUIEventListener LoadEvent handler globalWindow
+type State =
+  { markdown :: String
+  , formState :: SlamDownFormState
+  }
 
-appendToBody :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Unit
-appendToBody e = do
-  w <- document globalWindow
-  b <- body w
-  appendChild b e
+initialState :: State
+initialState =
+  { markdown : ""
+  , formState : SM.empty
+  }
 
-data State = State String SlamDownState
+data Query a = DocumentChanged String a
 
-data Input
-  = DocumentChanged String
-  | FormFieldChanged SlamDownEvent
+data SlamDownSlot = SlamDownSlot
 
-ui :: forall f eff. (Alternative f) => BrowserFeatures -> Component f Input Input
-ui browserFeatures = render <$> stateful (State "" (initSlamDownState $ SlamDown mempty)) update
+instance ordSlamDownSlot :: Ord SlamDownSlot where
+  compare _ _ = EQ
+
+instance eqSlamDownSlot :: Eq SlamDownSlot where
+  eq _ _ = true
+
+type DemoInstalledState g = H.InstalledState State SlamDownState Query SlamDownQuery g SlamDownSlot
+type DemoComponent g = H.Component (DemoInstalledState g) (Coproduct Query (H.ChildF SlamDownSlot SlamDownQuery)) g
+type DemoRender g = H.RenderParent State SlamDownState Query SlamDownQuery g SlamDownSlot
+type DemoEval g = H.EvalParent Query State SlamDownState Query SlamDownQuery g SlamDownSlot
+type DemoPeek f g = H.Peek f State SlamDownState Query SlamDownQuery g SlamDownSlot
+type DemoQueryF s g = H.QueryF State s Query SlamDownQuery g SlamDownSlot
+
+ui :: forall g. (Plus g) => SlamDownConfig -> DemoComponent g
+ui config = H.parentComponent' render eval peek
   where
-  render :: State -> H.HTML (f Input)
-  render (State md form) =
-    H.div [ A.class_ (A.className "container") ]
-          [ H.h2_ [ H.text "Markdown" ]
-          , H.div_ [ H.textarea [ A.class_ (A.className "form-control")
-                                , A.value md
-                                , A.onInput (A.input DocumentChanged)
-                                ] [] ]
-          , H.h2_ [ H.text "HTML Output" ]
-          , H.div [ A.class_ (A.className "well") ] (output md form)
-          , H.h2_ [ H.text "Form State" ]
-          , H.pre_ [ H.code_ [ H.text (show form) ] ]
-          ]
+    render :: DemoRender g
+    render state = do
+      H.div
+        [ P.class_ $ H.className "container" ]
+        [ H.h2_ [ H.text "Markdown" ]
+        , H.div_
+            [ H.textarea
+                [ P.class_ $ H.className "form-control"
+                , P.value state.markdown
+                , E.onValueInput $ E.input DocumentChanged
+                ]
+            ]
+        , H.h2_ [ H.text "HTML Output" ]
+        , H.div
+            [ P.class_ (H.className "well") ]
+            [ H.slot SlamDownSlot \_ ->
+                { component : slamDownComponent config
+                , initialState : emptySlamDownState
+                }
+            ]
+        , H.h2_ [ H.text "Form State" ]
+        , H.pre_ [ H.code_ [ H.text (show state.formState) ] ]
+        ]
 
-  output :: String -> SlamDownState -> Array (H.HTML (f Input))
-  output md form = ((FormFieldChanged <$>) <$>) <$> renderHalogen browserFeatures "slamdown-example" form (parseMd md)
+    eval :: DemoEval g
+    eval (DocumentChanged text next) = do
+      H.query SlamDownSlot <<< H.action <<< SetDocument $ parseMd text
+      updateFormState
+      pure next
 
-  update :: State -> Input -> State
-  update (State _ (SlamDownState form)) (DocumentChanged md) =
-    let slamdown = parseMd md
-    in case initSlamDownState slamdown of
-      SlamDownState emptyForm ->
-        let currentKeys = SM.keys emptyForm
-            oldKeys = SM.keys form \\ currentKeys
-            newForm = foldl (\f k -> SM.delete k f) (form `SM.union` emptyForm) oldKeys
-        in State md (SlamDownState newForm)
-  update (State s form) (FormFieldChanged e) = State s (applySlamDownEvent form e)
+    peek :: forall f. DemoPeek f g
+    peek _ = updateFormState
 
-main = onLoad do
+    updateFormState :: forall s. Free (H.HalogenF State Query (DemoQueryF s g)) Unit
+    updateFormState =
+      H.query SlamDownSlot (H.request GetFormState) >>=
+        maybe (pure unit) \formState -> H.modify (_ { formState = formState })
+
+main :: Eff (avar :: AVAR, err :: EXCEPTION, dom :: DOM) Unit
+main = do
   browserFeatures <- detectBrowserFeatures
-  Tuple node driver <- runUI $ ui browserFeatures
-  appendToBody node
-
+  let config = { formName : "slamdown-demo-form", browserFeatures : browserFeatures }
+  runAff throwException (const (pure unit)) $ do
+    app <- H.runUI (ui config) (H.installedState initialState)
+    H.appendToBody app.node

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "dependencies": {
     "gulp": "^3.9.0",
     "gulp-jsvalidate": "^2.0.0",
-    "gulp-purescript": "^0.5.0",
-    "purescript": "^0.7.1 && <= 0.7.2",
+    "gulp-purescript": "^0.7.0",
+    "purescript": "^0.7.4",
     "rimraf": "^2.4.1",
     "virtual-dom": "^2.0.1",
     "webpack-stream": "^2.0.0"


### PR DESCRIPTION
- dependency upgrades
- rearchitected to support halogen components model; in particular, the SlamDown document is now part of the component's state so that the document can change over time along with the form
- rewrote the demo

@garyb Would you mind reviewing this PR? (@beckyconning and @cryogenian are also welcome to review!). Since this is the first non-trivial thing I've done with the new Halogen, I'd appreciate any constructive feedback that you can give. Thanks!!

~~:fire: Please don't merge until Halogen `v0.5.0` has been released, and this PR has been updated to point at it. :fire:~~
