### PR TITLE
[demo] upgrade to halogen 0.5.2; switch around type synonyms

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "purescript-browserfeatures": "^0.4.1",
-    "purescript-halogen": "^0.5.0",
+    "purescript-halogen": "^0.5.2",
     "purescript-markdown": "^1.10.0",
     "purescript-validation": "^0.2.0",
     "purescript-prelude": "^0.1.2",


### PR DESCRIPTION
This updates the demo to use the new "granular" type synonyms available in Halogen 0.5.2. This does not warrant a new release, but I wanted to get it in so that the demo better reflected how you're supposed to do this stuff.
