### PR TITLE
Fix warnings, make default browser features pessimistic

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
   ],
   "dependencies": {
     "purescript-browserfeatures": "^0.4.1",
-    "purescript-halogen": "^0.5.2",
+    "purescript-halogen": "^0.5.8",
     "purescript-markdown": "^1.11.0",
     "purescript-prelude": "^0.1.2",
     "purescript-sets": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "gulp": "^3.9.0",
     "gulp-jsvalidate": "^2.0.0",
     "gulp-purescript": "^0.7.0",
-    "purescript": "^0.7.5",
+    "purescript": "^0.7.6",
     "rimraf": "^2.4.1",
     "virtual-dom": "^2.0.1",
     "webpack-stream": "^2.0.0"


### PR DESCRIPTION
@jonsterling I was all gung ho about it until I realised it meant imposing a `MonadEff (dom :: DOM | eff) g` constraint, as this component can be run purely if the `BrowserFeatures` are provided some other way. What do you think?
