### PR TITLE
0.9 updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 dist: trusty
 sudo: required
-node_js: 5
+node_js: 6
 install:
   - npm install
   - npm install -g bower

--- a/bower.json
+++ b/bower.json
@@ -16,12 +16,12 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-browserfeatures": "^0.4.1",
-    "purescript-halogen": "^0.8.0",
-    "purescript-markdown": "^5.0.0",
-    "purescript-prelude": "^0.1.2",
-    "purescript-sets": "^0.5.7",
-    "purescript-strongcheck": "^0.14.4",
-    "purescript-validation": "^0.2.0"
+    "purescript-browserfeatures": "^1.0.0",
+    "purescript-halogen": "^0.10.0",
+    "purescript-markdown": "^6.0.0",
+    "purescript-prelude": "^1.0.1",
+    "purescript-sets": "^1.0.0",
+    "purescript-strongcheck": "^1.0.0",
+    "purescript-validation": "^1.0.0"
   }
 }

--- a/example/src/Main.purs
+++ b/example/src/Main.purs
@@ -2,18 +2,16 @@ module Main where
 
 import Prelude
 
-import Control.Bind ((=<<))
-import Control.Monad.Aff.AVar (AVAR())
-import Control.Monad.Eff (Eff())
-import Control.Monad.Eff.Exception (EXCEPTION())
+import Control.Monad.Aff.AVar (AVAR)
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Exception (EXCEPTION)
 
-import Data.Functor.Coproduct (Coproduct())
+import Data.Functor.Coproduct (Coproduct)
 import Data.Foldable (for_)
 import Data.Maybe (Maybe(..), maybe)
-import Data.NaturalTransformation (Natural())
 import Data.StrMap as SM
 
-import DOM (DOM())
+import DOM (DOM)
 import DOM.BrowserFeatures.Detectors (detectBrowserFeatures)
 
 import Halogen as H
@@ -22,7 +20,7 @@ import Halogen.HTML.Indexed as HH
 import Halogen.HTML.Properties.Indexed as HP
 import Halogen.Util (runHalogenAff, awaitBody)
 
-import Text.Markdown.SlamDown.Halogen.Component (SlamDownConfig(), SlamDownState(), SlamDownQuery(..), SlamDownFormState(), slamDownComponent, emptySlamDownState)
+import Text.Markdown.SlamDown.Halogen.Component (SlamDownConfig, SlamDownState, SlamDownQuery(..), SlamDownFormState, slamDownComponent, emptySlamDownState)
 import Text.Markdown.SlamDown.Parser (parseMd)
 
 type State =
@@ -78,7 +76,7 @@ ui config = H.parentComponent { render, eval, peek: Just peek }
         , HH.pre_ [ HH.code_ [ HH.text (show state.formState) ] ]
         ]
 
-    eval ∷ Natural Query (DemoDSL g)
+    eval ∷ Query ~> DemoDSL g
     eval (DocumentChanged text next) = do
       for_ (parseMd text) \md →
         H.query SlamDownSlot $ H.action $ SetDocument md

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "example": "pulp browserify --include example/src --to example/example.js"
   },
   "devDependencies": {
-    "pulp": "^8.2.0",
-    "purescript": "^0.8.5",
+    "pulp": "^9.0.1",
+    "purescript": "^0.9.2",
     "purescript-psa": "^0.3.8",
     "rimraf": "^2.5.2"
   },

--- a/src/Text/Markdown/SlamDown/Halogen/Component.purs
+++ b/src/Text/Markdown/SlamDown/Halogen/Component.purs
@@ -15,6 +15,7 @@ import Prelude
 
 import Control.Alt ((<|>))
 
+import Data.Array as A
 import Data.BrowserFeatures (BrowserFeatures)
 import Data.Either as E
 import Data.Foldable as F
@@ -26,7 +27,7 @@ import Data.Set as Set
 import Data.String as S
 import Data.StrMap as SM
 import Data.Traversable (traverse)
-import Data.Validation as V
+import Data.Validation.Semigroup as V
 
 import Halogen as H
 import Halogen.HTML.Events.Indexed as HE
@@ -34,14 +35,12 @@ import Halogen.HTML.Indexed as HH
 import Halogen.HTML.Properties.Indexed as HP
 
 import Text.Markdown.SlamDown as SD
+import Text.Markdown.SlamDown.Halogen.Component.Query as SDQ
+import Text.Markdown.SlamDown.Halogen.Component.State as SDS
+import Text.Markdown.SlamDown.Halogen.Fresh as Fresh
+import Text.Markdown.SlamDown.Halogen.InputType as SDIT
 import Text.Markdown.SlamDown.Parser.Inline as SDPI
 import Text.Markdown.SlamDown.Pretty as SDPR
-
-import Text.Markdown.SlamDown.Halogen.InputType as SDIT
-import Text.Markdown.SlamDown.Halogen.Fresh as Fresh
-import Text.Markdown.SlamDown.Halogen.Component.State as SDS
-import Text.Markdown.SlamDown.Halogen.Component.Query as SDQ
-
 import Text.Parsing.Parser as P
 
 -- | By default, no features are enabled.
@@ -53,7 +52,8 @@ defaultBrowserFeatures =
 evalSlamDownQuery
   ∷ ∀ g v
   . (SD.Value v)
-  ⇒ H.Natural (SDQ.SlamDownQuery v) (H.ComponentDSL (SDS.SlamDownState v) (SDQ.SlamDownQuery v) g)
+  ⇒ SDQ.SlamDownQuery v
+  ~> H.ComponentDSL (SDS.SlamDownState v) (SDQ.SlamDownQuery v) g
 evalSlamDownQuery e =
   case e of
     SDQ.TextBoxChanged key tb next → do
@@ -98,8 +98,8 @@ evalSlamDownQuery e =
         update (M.Just cb @ (SD.CheckBoxes (Identity sel) (Identity vals))) =
           SD.CheckBoxes (pure $ sel') (pure vals)
           where
-            sel' = Set.toList $ Set.intersection (Set.fromList vals) $ updateSel $ Set.fromList sel
-        update _ = SD.CheckBoxes (pure $ Set.toList $ updateSel Set.empty) (pure $ L.singleton val)
+            sel' = L.fromFoldable $ Set.intersection (Set.fromFoldable vals) $ updateSel $ Set.fromFoldable sel
+        update _ = SD.CheckBoxes (pure $ L.fromFoldable $ updateSel Set.empty) (pure $ L.singleton val)
 
       H.modify \state →
         SDS.modifyFormState
@@ -116,7 +116,7 @@ evalSlamDownQuery e =
       H.modify \(SDS.SlamDownState { document }) →
         let
           desc = SDS.formDescFromDocument document
-          keysToPrune = L.filter (\newKey → not (newKey `SM.member` desc)) (L.toList (SM.keys values))
+          keysToPrune = L.filter (\newKey → not (newKey `SM.member` desc)) (L.fromFoldable (SM.keys values))
           prunedValues = F.foldr SM.delete values keysToPrune
         in
           SDS.SlamDownState
@@ -149,7 +149,7 @@ renderSlamDown config (SDS.SlamDownState state) =
       HH.div_
         <<< Fresh.runFresh config.formName
         <<< traverse renderBlock
-          $ L.fromList bs
+          $ A.fromFoldable bs
 
   where
     defaultFormState ∷ SDS.SlamDownFormState v
@@ -175,14 +175,14 @@ renderSlamDown config (SDS.SlamDownState state) =
         SD.Space → pure $ HH.text " "
         SD.SoftBreak → pure $ HH.text "\n"
         SD.LineBreak → pure $ HH.br_
-        SD.Emph is → HH.em_ <$> traverse renderInline (L.fromList is)
-        SD.Strong is → HH.strong_ <$> traverse renderInline (L.fromList is)
+        SD.Emph is → HH.em_ <$> traverse renderInline (A.fromFoldable is)
+        SD.Strong is → HH.strong_ <$> traverse renderInline (A.fromFoldable is)
         SD.Code _ c → pure $ HH.code_ [ HH.text c ]
         SD.Link body tgt → do
           let
             href (SD.InlineLink url) = url
-            href (SD.ReferenceLink tgt') = M.maybe "" ("#" ++ _) tgt'
-          HH.a [ HP.href $ href tgt ] <$> traverse renderInline (L.fromList body)
+            href (SD.ReferenceLink tgt') = M.maybe "" ("#" <> _) tgt'
+          HH.a [ HP.href $ href tgt ] <$> traverse renderInline (A.fromFoldable body)
         SD.Image body url →
           pure $ HH.img
             [ HP.src url
@@ -213,7 +213,7 @@ renderSlamDown config (SDS.SlamDownState state) =
             [ HP.class_ (HH.className "slamdown-field") ]
             [ HH.label
               (if requiresId then [ HP.for ident ] else [])
-              [ HH.text (label ++ requiredLabel) ]
+              [ HH.text (label <> requiredLabel) ]
             , el
             ]
 
@@ -235,18 +235,18 @@ renderSlamDown config (SDS.SlamDownState state) =
     renderBlock b =
       case b of
         SD.Paragraph is →
-          HH.p_ <$> traverse renderInline (L.fromList is)
+          HH.p_ <$> traverse renderInline (A.fromFoldable is)
         SD.Header lvl is →
-          h_ lvl <$> traverse renderInline (L.fromList is)
+          h_ lvl <$> traverse renderInline (A.fromFoldable is)
         SD.Blockquote bs →
-          HH.blockquote_ <$> traverse renderBlock (L.fromList bs)
+          HH.blockquote_ <$> traverse renderBlock (A.fromFoldable bs)
         SD.Lst lt bss → do
           let
             item ∷ FreshRenderer p v (L.List (SD.Block v))
-            item bs = HH.li_ <$> traverse renderBlock (L.fromList bs)
-          el_ lt <$> traverse item (L.fromList bss)
+            item bs = HH.li_ <$> traverse renderBlock (A.fromFoldable bs)
+          el_ lt <$> traverse item (A.fromFoldable bss)
         SD.CodeBlock _ ss →
-          pure $ HH.pre_ [ HH.code_ [ HH.text (S.joinWith "\n" $ L.fromList ss) ] ]
+          pure $ HH.pre_ [ HH.code_ [ HH.text (S.joinWith "\n" $ A.fromFoldable ss) ] ]
         SD.LinkReference l url →
           pure $ HH.p_
             [ HH.text (l <> ": ")
@@ -258,7 +258,7 @@ renderSlamDown config (SDS.SlamDownState state) =
     -- | Make sure that the default value of a form field is valid, and if it is not, strip it out.
     ensureValidField ∷ SD.FormField v → SD.FormField v
     ensureValidField field =
-      V.runV
+      V.unV
         (const $ stripDefaultValue field)
         id
         (SDPI.validateFormField field)
@@ -326,7 +326,7 @@ renderDropDown id label ls sel =
     , HP.name label
     , HE.onSelectedIndexChange (HE.input (SDQ.DropDownChanged label <<< L.index ls))
     ]
-    $ L.fromList $ M.maybe option option' sel <$> ls
+    $ A.fromFoldable $ M.maybe option option' sel <$> ls
   where
     option ∷ v → H.HTML p (SDQ.SlamDownQuery v)
     option value =
@@ -353,15 +353,15 @@ renderFormElement config st id label field =
     SD.RadioButtons (Identity sel) (Identity ls) → do
       let
         renderRadioButton' val = renderRadioButton label val $ sel == val
-        options = L.fromList $ if sel `F.elem` ls then ls else L.Cons sel ls
+        options = A.fromFoldable $ if sel `F.elem` ls then ls else L.Cons sel ls
       radios ← traverse renderRadioButton' options
       pure $ HH.ul [ HP.class_ (HH.className "slamdown-radios") ] radios
     SD.CheckBoxes (Identity sel) (Identity ls) → do
       let
-        sel' = Set.fromList sel
+        sel' = Set.fromFoldable sel
         renderCheckBox' val = renderCheckBox label val (Set.member val sel')
       checkBoxes ← traverse renderCheckBox' ls
-      pure $ HH.ul [ HP.class_ (HH.className "slamdown-checkboxes") ] $ L.fromList checkBoxes
+      pure $ HH.ul [ HP.class_ (HH.className "slamdown-checkboxes") ] $ A.fromFoldable checkBoxes
     SD.DropDown msel (Identity ls) →
       pure $
         case msel of

--- a/src/Text/Markdown/SlamDown/Halogen/Component/Query.purs
+++ b/src/Text/Markdown/SlamDown/Halogen/Component/Query.purs
@@ -5,10 +5,11 @@ module Text.Markdown.SlamDown.Halogen.Component.Query
 import Prelude
 
 import Data.Maybe as M
-import Data.NaturalTransformation (Natural)
 import Data.StrMap as SM
-import Test.StrongCheck as SC
+
+import Test.StrongCheck.Arbitrary as SCA
 import Test.StrongCheck.Gen as Gen
+
 import Text.Markdown.SlamDown as SD
 import Text.Markdown.SlamDown.Halogen.Component.State as SDS
 
@@ -34,26 +35,25 @@ instance functorSlamDownQuery ∷ Functor (SlamDownQuery v) where
 
 newtype ArbStrMap a = ArbStrMap (SM.StrMap a)
 
-getArbStrMap ∷ Natural ArbStrMap SM.StrMap
+getArbStrMap ∷ ArbStrMap ~> SM.StrMap
 getArbStrMap (ArbStrMap a) = a
 
-instance arbitraryArbStrMap ∷ (SC.Arbitrary a) ⇒ SC.Arbitrary (ArbStrMap a) where
+instance arbitraryArbStrMap ∷ (SCA.Arbitrary a) ⇒ SCA.Arbitrary (ArbStrMap a) where
   arbitrary =
-    ArbStrMap <<< SM.fromList <$> SC.arbitrary
+    ArbStrMap <<< SM.fromList <$> SCA.arbitrary
 
-instance coarbitraryArbStrMap ∷ (SC.CoArbitrary a) ⇒ SC.CoArbitrary (ArbStrMap a) where
+instance coarbitraryArbStrMap ∷ (SCA.Coarbitrary a) ⇒ SCA.Coarbitrary (ArbStrMap a) where
   coarbitrary (ArbStrMap a) =
-    SC.coarbitrary (SM.toList a)
+    SCA.coarbitrary (SM.toList a)
 
-instance arbitrarySlamDownQuery ∷ (SC.Arbitrary v, SC.CoArbitrary v, SC.Arbitrary a, Eq v) ⇒ SC.Arbitrary (SlamDownQuery v a) where
+instance arbitrarySlamDownQuery ∷ (SCA.Arbitrary v, SCA.Coarbitrary v, SCA.Arbitrary a, Eq v) ⇒ SCA.Arbitrary (SlamDownQuery v a) where
   arbitrary = do
     i ← Gen.chooseInt 0.0 6.0
     case i of
-      0 -> TextBoxChanged <$> SC.arbitrary <*> SC.arbitrary <*> SC.arbitrary
-      1 -> CheckBoxChanged <$> SC.arbitrary <*> SC.arbitrary <*> SC.arbitrary <*> SC.arbitrary
-      2 -> RadioButtonChanged <$> SC.arbitrary <*> SC.arbitrary <*> SC.arbitrary
-      3 -> DropDownChanged <$> SC.arbitrary <*> SC.arbitrary <*> SC.arbitrary
-      4 -> SetDocument <$> SC.arbitrary <*> SC.arbitrary
-      5 -> GetFormState <<< (_ <<< ArbStrMap) <$> SC.arbitrary
-      _ -> PopulateForm <<< getArbStrMap <$> SC.arbitrary <*> SC.arbitrary
-
+      0 -> TextBoxChanged <$> SCA.arbitrary <*> SCA.arbitrary <*> SCA.arbitrary
+      1 -> CheckBoxChanged <$> SCA.arbitrary <*> SCA.arbitrary <*> SCA.arbitrary <*> SCA.arbitrary
+      2 -> RadioButtonChanged <$> SCA.arbitrary <*> SCA.arbitrary <*> SCA.arbitrary
+      3 -> DropDownChanged <$> SCA.arbitrary <*> SCA.arbitrary <*> SCA.arbitrary
+      4 -> SetDocument <$> SCA.arbitrary <*> SCA.arbitrary
+      5 -> GetFormState <<< (_ <<< ArbStrMap) <$> SCA.arbitrary
+      _ -> PopulateForm <<< getArbStrMap <$> SCA.arbitrary <*> SCA.arbitrary

--- a/src/Text/Markdown/SlamDown/Halogen/Fresh.purs
+++ b/src/Text/Markdown/SlamDown/Halogen/Fresh.purs
@@ -8,7 +8,6 @@ module Text.Markdown.SlamDown.Halogen.Fresh
 import Prelude
 
 import Data.Identity (Identity, runIdentity)
-import Data.NaturalTransformation (Natural)
 import Control.Monad.Reader.Trans (ReaderT, runReaderT, ask)
 import Control.Monad.State.Trans (StateT, evalStateT)
 import Control.Monad.State.Class (get, modify)
@@ -30,7 +29,8 @@ runFreshT
   ∷ ∀ m
   . (Monad m)
   ⇒ String
-  → Natural (FreshT m) m
+  → FreshT m
+  ~> m
 runFreshT prefix m =
   evalStateT
     (runReaderT m prefix)

--- a/src/Text/Markdown/SlamDown/Halogen/InputType.purs
+++ b/src/Text/Markdown/SlamDown/Halogen/InputType.purs
@@ -2,7 +2,9 @@ module Text.Markdown.SlamDown.Halogen.InputType where
 
 import Data.BrowserFeatures (BrowserFeatures)
 import Data.BrowserFeatures.InputType as IT
+
 import Halogen.HTML.Properties.Indexed as HP
+
 import Text.Markdown.SlamDown as SD
 
 availableInputType
@@ -26,8 +28,8 @@ textBoxToInputType ty =
   case ty of
     SD.PlainText _ → IT.Text
     SD.Date _ → IT.Date
-    SD.Time _ → IT.Time
-    SD.DateTime _ → IT.DateTimeLocal
+    SD.Time _ _ → IT.Time
+    SD.DateTime _ _ → IT.DateTimeLocal
     SD.Numeric _ → IT.Number
 
 inputTypeToHalogenInputType
@@ -48,4 +50,3 @@ inputTypeToHalogenInputType it =
     IT.Search → HP.InputSearch
     IT.Range → HP.InputRange
     IT.Text → HP.InputText
-


### PR DESCRIPTION
@natefaubion Can you review the change to support seconds please? It's testable using the example page.

Seconds are enabled when the `__ : __ : __` form rather than `__ : __` is used in time/datetime markdown.
