### PR TITLE
Fix form state synchronization

### DIFF
--- a/src/Text/Markdown/SlamDown/Halogen/Component.purs
+++ b/src/Text/Markdown/SlamDown/Halogen/Component.purs
@@ -128,15 +128,7 @@ evalSlamDownQuery e =
 
     SDQ.PopulateForm values next → do
       H.modify \(SDS.SlamDownState { document }) →
-        let
-          desc = SDS.formDescFromDocument document
-          keysToPrune = L.filter (\newKey → not (newKey `SM.member` desc)) (L.fromFoldable (SM.keys values))
-          prunedValues = F.foldr SM.delete values keysToPrune
-        in
-          SDS.SlamDownState
-            { document
-            , formState: prunedValues
-            }
+        SDS.syncState document values
       pure next
 
     SDQ.SetDocument doc next → do


### PR DESCRIPTION
It was only removing a key if the input type was the same, but the value's were not equal. If the input types were not equal, it favored the `formState` instead of the document. It should always favor the document.