### PR TITLE
Update dependencies and InputType mapping to remove obsolete feature

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "purescript-halogen-datepicker": "^0.1.0",
     "purescript-browserfeatures": "^4.0.0",
-    "purescript-halogen": "^2.0.1",
+    "purescript-halogen": "^3.0.1",
     "purescript-markdown": "^11.0.0",
     "purescript-prelude": "^3.0.0",
     "purescript-sets": "^3.0.0",

--- a/src/Text/Markdown/SlamDown/Halogen/InputType.purs
+++ b/src/Text/Markdown/SlamDown/Halogen/InputType.purs
@@ -39,7 +39,7 @@ inputTypeToHalogenInputType it =
   case it of
     IT.Color → HP.InputColor
     IT.Date → HP.InputDate
-    IT.DateTime → HP.InputDatetime
+    IT.DateTime → HP.InputDatetimeLocal
     IT.DateTimeLocal → HP.InputDatetimeLocal
     IT.Time → HP.InputTime
     IT.Month → HP.InputMonth


### PR DESCRIPTION
I'd like to use this in a component in a Halogen project, but because Halogen has a new major version number (2 -> 3), this package is incompatible. I bumped the major version number and found that it will fail to build for two reasons:

**This package relies on `purescript-halogen-datepicker`, which itself is still on Halogen 2.1.0.** 
This can be resolved with [this pull request to update that package's dependencies](https://github.com/slamdata/purescript-halogen-datepicker/pull/4).

**The `InputType.purs` file maps browser input types to Halogen properties.** 
Halogen 3.0.0 removes an obsolute browser input type, "datetime", and keeps the still-supported one, "datetime-local." However, the `browserfeatures` package has not been updated to remove that obsolete feature -- as noted in [this issue on the `browserfeatures` repo](https://github.com/slamdata/purescript-browserfeatures/issues/17). In _this_ package, the browser features are mapped to Halogen properties, including the now-removed `DateTime`.

In this PR I've fixed this by mapping the browserfeatures `DateTime` type to the Halogen `DateTimeLocal` type. However, since SlamData also owns the browserfeatures package, I suppose you could just remove the type from that package, too, and then delete the line altogether in this package.


This package can't be updated until the two issues above are resolved, but at that point this will again become usable in Halogen 3.0.0 projects.