### PR TITLE
query datetimepickers when input type is _not_ supported

### DIFF
--- a/src/Text/Markdown/SlamDown/Halogen/Component.purs
+++ b/src/Text/Markdown/SlamDown/Halogen/Component.purs
@@ -159,11 +159,11 @@ updatePickers :: ∀ m v a
   → DSL v m Unit
 updatePickers {inputTypeSupported} _ label = case _ of
   SD.TextBox t → case t of
-    SD.DateTime _ (Compose (Just (Identity v))) | inputTypeSupported IT.DateTimeLocal →
+    SD.DateTime _ (Compose (Just (Identity v))) | not inputTypeSupported IT.DateTimeLocal →
       void (H.query' cpDateTimePicker label $ setValue $ Just $ Right v)
-    SD.Time _ (Compose (Just (Identity v))) | inputTypeSupported IT.DateTimeLocal →
+    SD.Time _ (Compose (Just (Identity v))) | not inputTypeSupported IT.DateTimeLocal →
       void (H.query' cpTimePicker label $ setValue $ Just $ Right v)
-    SD.Date (Compose (Just (Identity v))) | inputTypeSupported IT.DateTimeLocal →
+    SD.Date (Compose (Just (Identity v))) | not inputTypeSupported IT.DateTimeLocal →
       void (H.query' cpDatePicker label $ setValue $ Just $ Right v)
     _ → pure unit
   _ → pure unit


### PR DESCRIPTION
@safareli this should fix sd-3025, please take a look